### PR TITLE
Refactor scratch data allocation to fix ESP8266

### DIFF
--- a/utility/MLX90640_API.cpp
+++ b/utility/MLX90640_API.cpp
@@ -19,6 +19,8 @@
 #include "../Adafruit_MLX90640.h"
 #include <math.h>
 
+static float scratchData[768];
+
 void ExtractVDDParameters(uint16_t *eeData, paramsMLX90640 *mlx90640);
 void ExtractPTATParameters(uint16_t *eeData, paramsMLX90640 *mlx90640);
 void ExtractGainParameters(uint16_t *eeData, paramsMLX90640 *mlx90640);
@@ -33,7 +35,7 @@ void ExtractKvPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640);
 void ExtractCPParameters(uint16_t *eeData, paramsMLX90640 *mlx90640);
 void ExtractCILCParameters(uint16_t *eeData, paramsMLX90640 *mlx90640);
 int ExtractDeviatingPixels(uint16_t *eeData, paramsMLX90640 *mlx90640);
-int CheckAdjacentPixels(uint16_t pix1, uint16_t pix2);  
+int CheckAdjacentPixels(uint16_t pix1, uint16_t pix2);
 float GetMedian(float *values, int n);
 int IsPixelBad(uint16_t pixel,paramsMLX90640 *params);
 
@@ -49,7 +51,7 @@ int Adafruit_MLX90640::MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameD
     uint16_t statusRegister;
     int error = 1;
     uint8_t cnt = 0;
-    
+
     dataReady = 0;
     while(dataReady == 0)
     {
@@ -57,15 +59,15 @@ int Adafruit_MLX90640::MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameD
         if(error != 0)
         {
             return error;
-        }    
+        }
         dataReady = statusRegister & 0x0008;
 #ifdef MLX90640_DEBUG
 	Serial.printf("ready status: 0x%x\n", dataReady);
 #endif
     }
-        
+
     while(dataReady != 0 && cnt < 5)
-    { 
+    {
         error = MLX90640_I2CWrite(slaveAddr, 0x8000, 0x0030);
         if(error == -1)
         {
@@ -74,48 +76,48 @@ int Adafruit_MLX90640::MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameD
 #ifdef MLX90640_DEBUG
         Serial.printf("Read frame %d\n", cnt);
 #endif
-        error = MLX90640_I2CRead(slaveAddr, 0x0400, 832, frameData); 
+        error = MLX90640_I2CRead(slaveAddr, 0x0400, 832, frameData);
         if(error != 0)
         {
             return error;
         }
-                   
+
         error = MLX90640_I2CRead(slaveAddr, 0x8000, 1, &statusRegister);
         if(error != 0)
         {
             return error;
-        }    
+        }
         dataReady = statusRegister & 0x0008;
 #ifdef MLX90640_DEBUG
 	Serial.printf("frame ready: 0x%x\n", dataReady);
 #endif
         cnt = cnt + 1;
     }
-    
+
     if(cnt > 4)
     {
 #ifdef MLX90640_DEBUG
       Serial.printf("TOO MANY RETRIES");
 #endif
         return -8;
-    }    
-    
+    }
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
     frameData[832] = controlRegister1;
     frameData[833] = statusRegister & 0x0001;
-    
+
     if(error != 0)
     {
         return error;
     }
-    
-    return frameData[833];    
+
+    return frameData[833];
 }
 
 int Adafruit_MLX90640::MLX90640_ExtractParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 {
     int error = 0;
-    
+
     ExtractVDDParameters(eeData, mlx90640);
     ExtractPTATParameters(eeData, mlx90640);
     ExtractGainParameters(eeData, mlx90640);
@@ -129,8 +131,8 @@ int Adafruit_MLX90640::MLX90640_ExtractParameters(uint16_t *eeData, paramsMLX906
     ExtractKtaPixelParameters(eeData, mlx90640);
     ExtractKvPixelParameters(eeData, mlx90640);
     ExtractCILCParameters(eeData, mlx90640);
-    error = ExtractDeviatingPixels(eeData, mlx90640);  
-    
+    error = ExtractDeviatingPixels(eeData, mlx90640);
+
     return error;
 
 }
@@ -142,17 +144,17 @@ int Adafruit_MLX90640::MLX90640_SetResolution(uint8_t slaveAddr, uint8_t resolut
     uint16_t controlRegister1;
     int value;
     int error;
-    
+
     value = (resolution & 0x03) << 10;
-    
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
-    
+
     if(error == 0)
     {
         value = (controlRegister1 & 0xF3FF) | value;
-        error = MLX90640_I2CWrite(slaveAddr, 0x800D, value);        
-    }    
-    
+        error = MLX90640_I2CWrite(slaveAddr, 0x800D, value);
+    }
+
     return error;
 }
 
@@ -163,15 +165,15 @@ int Adafruit_MLX90640::MLX90640_GetCurResolution(uint8_t slaveAddr)
     uint16_t controlRegister1;
     int resolutionRAM;
     int error;
-    
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
     if(error != 0)
     {
         return error;
-    }    
+    }
     resolutionRAM = (controlRegister1 & 0x0C00) >> 10;
-    
-    return resolutionRAM; 
+
+    return resolutionRAM;
 }
 
 //------------------------------------------------------------------------------
@@ -181,16 +183,16 @@ int Adafruit_MLX90640::MLX90640_SetRefreshRate(uint8_t slaveAddr, uint8_t refres
     uint16_t controlRegister1;
     int value;
     int error;
-    
+
     value = (refreshRate & 0x07)<<7;
-    
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
     if(error == 0)
     {
         value = (controlRegister1 & 0xFC7F) | value;
         error = MLX90640_I2CWrite(slaveAddr, 0x800D, value);
-    }    
-    
+    }
+
     return error;
 }
 
@@ -201,14 +203,14 @@ int Adafruit_MLX90640::MLX90640_GetRefreshRate(uint8_t slaveAddr)
     uint16_t controlRegister1;
     int refreshRate;
     int error;
-    
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
     if(error != 0)
     {
         return error;
-    }    
+    }
     refreshRate = (controlRegister1 & 0x0380) >> 7;
-    
+
     return refreshRate;
 }
 
@@ -219,15 +221,15 @@ int Adafruit_MLX90640::MLX90640_SetInterleavedMode(uint8_t slaveAddr)
     uint16_t controlRegister1;
     int value;
     int error;
-    
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
-    
+
     if(error == 0)
     {
         value = (controlRegister1 & 0xEFFF);
-        error = MLX90640_I2CWrite(slaveAddr, 0x800D, value);        
-    }    
-    
+        error = MLX90640_I2CWrite(slaveAddr, 0x800D, value);
+    }
+
     return error;
 }
 
@@ -238,15 +240,15 @@ int Adafruit_MLX90640::MLX90640_SetChessMode(uint8_t slaveAddr)
     uint16_t controlRegister1;
     int value;
     int error;
-        
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
-    
+
     if(error == 0)
     {
         value = (controlRegister1 | 0x1000);
-        error = MLX90640_I2CWrite(slaveAddr, 0x800D, value);        
-    }    
-    
+        error = MLX90640_I2CWrite(slaveAddr, 0x800D, value);
+    }
+
     return error;
 }
 
@@ -257,15 +259,15 @@ int Adafruit_MLX90640::MLX90640_GetCurMode(uint8_t slaveAddr)
     uint16_t controlRegister1;
     int modeRAM;
     int error;
-    
+
     error = MLX90640_I2CRead(slaveAddr, 0x800D, 1, &controlRegister1);
     if(error != 0)
     {
         return error;
-    }    
+    }
     modeRAM = (controlRegister1 & 0x1000) >> 12;
-    
-    return modeRAM; 
+
+    return modeRAM;
 }
 
 //------------------------------------------------------------------------------
@@ -296,11 +298,11 @@ void Adafruit_MLX90640::MLX90640_CalculateTo(uint16_t *frameData, const paramsML
     float alphaScale;
     float kta;
     float kv;
-    
+
     subPage = frameData[833];
     vdd = MLX90640_GetVdd(frameData, params);
     ta = MLX90640_GetTa(frameData, params);
-    
+
     ta4 = (ta + 273.15);
     ta4 = ta4 * ta4;
     ta4 = ta4 * ta4;
@@ -308,29 +310,29 @@ void Adafruit_MLX90640::MLX90640_CalculateTo(uint16_t *frameData, const paramsML
     tr4 = tr4 * tr4;
     tr4 = tr4 * tr4;
     taTr = tr4 - (tr4-ta4)/emissivity;
-    
+
     ktaScale = pow(2,(double)params->ktaScale);
     kvScale = pow(2,(double)params->kvScale);
     alphaScale = pow(2,(double)params->alphaScale);
-    
+
     alphaCorrR[0] = 1 / (1 + params->ksTo[0] * 40);
     alphaCorrR[1] = 1 ;
     alphaCorrR[2] = (1 + params->ksTo[1] * params->ct[2]);
     alphaCorrR[3] = alphaCorrR[2] * (1 + params->ksTo[2] * (params->ct[3] - params->ct[2]));
-    
-//------------------------- Gain calculation -----------------------------------    
+
+//------------------------- Gain calculation -----------------------------------
     gain = frameData[778];
     if(gain > 32767)
     {
         gain = gain - 65536;
     }
-    
-    gain = params->gainEE / gain; 
-  
-//------------------------- To calculation -------------------------------------    
+
+    gain = params->gainEE / gain;
+
+//------------------------- To calculation -------------------------------------
     mode = (frameData[832] & 0x1000) >> 5;
-    
-    irDataCP[0] = frameData[776];  
+
+    irDataCP[0] = frameData[776];
     irDataCP[1] = frameData[808];
     for( int i = 0; i < 2; i++)
     {
@@ -352,67 +354,67 @@ void Adafruit_MLX90640::MLX90640_CalculateTo(uint16_t *frameData, const paramsML
 
     for( int pixelNumber = 0; pixelNumber < 768; pixelNumber++)
     {
-        ilPattern = pixelNumber / 32 - (pixelNumber / 64) * 2; 
-        chessPattern = ilPattern ^ (pixelNumber - (pixelNumber/2)*2); 
+        ilPattern = pixelNumber / 32 - (pixelNumber / 64) * 2;
+        chessPattern = ilPattern ^ (pixelNumber - (pixelNumber/2)*2);
         conversionPattern = ((pixelNumber + 2) / 4 - (pixelNumber + 3) / 4 + (pixelNumber + 1) / 4 - pixelNumber / 4) * (1 - 2 * ilPattern);
-        
+
         if(mode == 0)
         {
-          pattern = ilPattern; 
+          pattern = ilPattern;
         }
-        else 
+        else
         {
-          pattern = chessPattern; 
-        }               
-        
+          pattern = chessPattern;
+        }
+
         if(pattern == frameData[833])
-        {    
+        {
             irData = frameData[pixelNumber];
             if(irData > 32767)
             {
                 irData = irData - 65536;
             }
             irData = irData * gain;
-            
+
             kta = params->kta[pixelNumber]/ktaScale;
             kv = params->kv[pixelNumber]/kvScale;
             irData = irData - params->offset[pixelNumber]*(1 + kta*(ta - 25))*(1 + kv*(vdd - 3.3));
-            
+
             if(mode !=  params->calibrationModeEE)
             {
-              irData = irData + params->ilChessC[2] * (2 * ilPattern - 1) - params->ilChessC[1] * conversionPattern; 
-            }                       
-    
+              irData = irData + params->ilChessC[2] * (2 * ilPattern - 1) - params->ilChessC[1] * conversionPattern;
+            }
+
             irData = irData - params->tgc * irDataCP[subPage];
             irData = irData / emissivity;
-            
+
             alphaCompensated = SCALEALPHA*alphaScale/params->alpha[pixelNumber];
             alphaCompensated = alphaCompensated*(1 + params->KsTa * (ta - 25));
-                        
+
             Sx = alphaCompensated * alphaCompensated * alphaCompensated * (irData + alphaCompensated * taTr);
-            Sx = sqrt(sqrt(Sx)) * params->ksTo[1];            
-            
-            To = sqrt(sqrt(irData/(alphaCompensated * (1 - params->ksTo[1] * 273.15) + Sx) + taTr)) - 273.15;                     
-                    
+            Sx = sqrt(sqrt(Sx)) * params->ksTo[1];
+
+            To = sqrt(sqrt(irData/(alphaCompensated * (1 - params->ksTo[1] * 273.15) + Sx) + taTr)) - 273.15;
+
             if(To < params->ct[1])
             {
                 range = 0;
             }
-            else if(To < params->ct[2])   
+            else if(To < params->ct[2])
             {
-                range = 1;            
-            }   
+                range = 1;
+            }
             else if(To < params->ct[3])
             {
-                range = 2;            
+                range = 2;
             }
             else
             {
-                range = 3;            
-            }      
-            
+                range = 3;
+            }
+
             To = sqrt(sqrt(irData / (alphaCompensated * alphaCorrR[range] * (1 + params->ksTo[range] * (To - params->ct[range]))) + taTr)) - 273.15;
-                        
+
             result[pixelNumber] = To;
         }
     }
@@ -439,27 +441,27 @@ void Adafruit_MLX90640::MLX90640_GetImage(uint16_t *frameData, const paramsMLX90
     float kvScale;
     float kta;
     float kv;
-    
+
     subPage = frameData[833];
     vdd = MLX90640_GetVdd(frameData, params);
     ta = MLX90640_GetTa(frameData, params);
-    
+
     ktaScale = pow(2,(double)params->ktaScale);
     kvScale = pow(2,(double)params->kvScale);
-    
-//------------------------- Gain calculation -----------------------------------    
+
+//------------------------- Gain calculation -----------------------------------
     gain = frameData[778];
     if(gain > 32767)
     {
         gain = gain - 65536;
     }
-    
-    gain = params->gainEE / gain; 
-  
-//------------------------- Image calculation -------------------------------------    
+
+    gain = params->gainEE / gain;
+
+//------------------------- Image calculation -------------------------------------
     mode = (frameData[832] & 0x1000) >> 5;
-    
-    irDataCP[0] = frameData[776];  
+
+    irDataCP[0] = frameData[776];
     irDataCP[1] = frameData[808];
     for( int i = 0; i < 2; i++)
     {
@@ -481,43 +483,43 @@ void Adafruit_MLX90640::MLX90640_GetImage(uint16_t *frameData, const paramsMLX90
 
     for( int pixelNumber = 0; pixelNumber < 768; pixelNumber++)
     {
-        ilPattern = pixelNumber / 32 - (pixelNumber / 64) * 2; 
-        chessPattern = ilPattern ^ (pixelNumber - (pixelNumber/2)*2); 
+        ilPattern = pixelNumber / 32 - (pixelNumber / 64) * 2;
+        chessPattern = ilPattern ^ (pixelNumber - (pixelNumber/2)*2);
         conversionPattern = ((pixelNumber + 2) / 4 - (pixelNumber + 3) / 4 + (pixelNumber + 1) / 4 - pixelNumber / 4) * (1 - 2 * ilPattern);
-        
+
         if(mode == 0)
         {
-          pattern = ilPattern; 
+          pattern = ilPattern;
         }
-        else 
+        else
         {
-          pattern = chessPattern; 
+          pattern = chessPattern;
         }
-        
+
         if(pattern == frameData[833])
-        {    
+        {
             irData = frameData[pixelNumber];
             if(irData > 32767)
             {
                 irData = irData - 65536;
             }
             irData = irData * gain;
-            
+
             kta = params->kta[pixelNumber]/ktaScale;
             kv = params->kv[pixelNumber]/kvScale;
             irData = irData - params->offset[pixelNumber]*(1 + kta*(ta - 25))*(1 + kv*(vdd - 3.3));
 
             if(mode !=  params->calibrationModeEE)
             {
-              irData = irData + params->ilChessC[2] * (2 * ilPattern - 1) - params->ilChessC[1] * conversionPattern; 
+              irData = irData + params->ilChessC[2] * (2 * ilPattern - 1) - params->ilChessC[1] * conversionPattern;
             }
-            
+
             irData = irData - params->tgc * irDataCP[subPage];
-                        
+
             alphaCompensated = params->alpha[pixelNumber];
-            
+
             image = irData*alphaCompensated;
-            
+
             result[pixelNumber] = image;
         }
     }
@@ -530,8 +532,8 @@ float Adafruit_MLX90640::MLX90640_GetVdd(uint16_t *frameData, const paramsMLX906
     float vdd;
     float resolutionCorrection;
 
-    int resolutionRAM;    
-    
+    int resolutionRAM;
+
     vdd = frameData[810];
     if(vdd > 32767)
     {
@@ -540,7 +542,7 @@ float Adafruit_MLX90640::MLX90640_GetVdd(uint16_t *frameData, const paramsMLX906
     resolutionRAM = (frameData[832] & 0x0C00) >> 10;
     resolutionCorrection = pow(2, (double)params->resolutionEE) / pow(2, (double)resolutionRAM);
     vdd = (resolutionCorrection * vdd - params->vdd25) / params->kVdd + 3.3;
-    
+
     return vdd;
 }
 
@@ -552,7 +554,7 @@ float Adafruit_MLX90640::MLX90640_GetTa(uint16_t *frameData, const paramsMLX9064
     float ptatArt;
     float vdd;
     float ta;
-    
+
     vdd = MLX90640_GetVdd(frameData, params);
 #ifdef MLX90640_DEBUG
     Serial.print("vdd = "); Serial.println(vdd);
@@ -563,7 +565,7 @@ float Adafruit_MLX90640::MLX90640_GetTa(uint16_t *frameData, const paramsMLX9064
     {
         ptat = ptat - 65536;
     }
-    
+
 #ifdef MLX90640_DEBUG
     Serial.print("ptat = "); Serial.println(ptat);
 #endif
@@ -577,10 +579,10 @@ float Adafruit_MLX90640::MLX90640_GetTa(uint16_t *frameData, const paramsMLX9064
 #ifdef MLX90640_DEBUG
     Serial.print("ptatart = "); Serial.println(ptatArt);
 #endif
-    
+
     ta = (ptatArt / (1 + params->KvPTAT * (vdd - 3.3)) - params->vPTAT25);
     ta = ta / params->KtPTAT + 25;
-    
+
     return ta;
 }
 
@@ -588,64 +590,64 @@ float Adafruit_MLX90640::MLX90640_GetTa(uint16_t *frameData, const paramsMLX9064
 
 int Adafruit_MLX90640::MLX90640_GetSubPageNumber(uint16_t *frameData)
 {
-    return frameData[833];    
+    return frameData[833];
 
-}    
+}
 
 //------------------------------------------------------------------------------
 void Adafruit_MLX90640::MLX90640_BadPixelsCorrection(uint16_t *pixels, float *to, int mode, paramsMLX90640 *params)
-{   
+{
     float ap[4];
     uint8_t pix;
     uint8_t line;
     uint8_t column;
-    
+
     pix = 0;
     while(pixels[pix] != 0xFFFF)
     {
         line = pixels[pix]>>5;
         column = pixels[pix] - (line<<5);
-        
+
         if(mode == 1)
-        {        
+        {
             if(line == 0)
             {
                 if(column == 0)
-                {        
-                    to[pixels[pix]] = to[33];                    
+                {
+                    to[pixels[pix]] = to[33];
                 }
                 else if(column == 31)
                 {
-                    to[pixels[pix]] = to[62];                      
+                    to[pixels[pix]] = to[62];
                 }
                 else
                 {
-                    to[pixels[pix]] = (to[pixels[pix]+31] + to[pixels[pix]+33])/2.0;                    
-                }        
+                    to[pixels[pix]] = (to[pixels[pix]+31] + to[pixels[pix]+33])/2.0;
+                }
             }
             else if(line == 23)
             {
                 if(column == 0)
                 {
-                    to[pixels[pix]] = to[705];                    
+                    to[pixels[pix]] = to[705];
                 }
                 else if(column == 31)
                 {
-                    to[pixels[pix]] = to[734];                       
+                    to[pixels[pix]] = to[734];
                 }
                 else
                 {
-                    to[pixels[pix]] = (to[pixels[pix]-33] + to[pixels[pix]-31])/2.0;                       
-                }                       
-            } 
+                    to[pixels[pix]] = (to[pixels[pix]-33] + to[pixels[pix]-31])/2.0;
+                }
+            }
             else if(column == 0)
             {
-                to[pixels[pix]] = (to[pixels[pix]-31] + to[pixels[pix]+33])/2.0;                
+                to[pixels[pix]] = (to[pixels[pix]-31] + to[pixels[pix]+33])/2.0;
             }
             else if(column == 31)
             {
-                to[pixels[pix]] = (to[pixels[pix]-33] + to[pixels[pix]+31])/2.0;                
-            } 
+                to[pixels[pix]] = (to[pixels[pix]-33] + to[pixels[pix]+31])/2.0;
+            }
             else
             {
                 ap[0] = to[pixels[pix]-33];
@@ -653,22 +655,22 @@ void Adafruit_MLX90640::MLX90640_BadPixelsCorrection(uint16_t *pixels, float *to
                 ap[2] = to[pixels[pix]+31];
                 ap[3] = to[pixels[pix]+33];
                 to[pixels[pix]] = GetMedian(ap,4);
-            }                   
+            }
         }
         else
-        {        
+        {
             if(column == 0)
             {
-                to[pixels[pix]] = to[pixels[pix]+1];            
+                to[pixels[pix]] = to[pixels[pix]+1];
             }
             else if(column == 1 || column == 30)
             {
-                to[pixels[pix]] = (to[pixels[pix]-1]+to[pixels[pix]+1])/2.0;                
-            } 
+                to[pixels[pix]] = (to[pixels[pix]-1]+to[pixels[pix]+1])/2.0;
+            }
             else if(column == 31)
             {
                 to[pixels[pix]] = to[pixels[pix]-1];
-            } 
+            }
             else
             {
                 if(IsPixelBad(pixels[pix]-2,params) == 0 && IsPixelBad(pixels[pix]+2,params) == 0)
@@ -677,21 +679,21 @@ void Adafruit_MLX90640::MLX90640_BadPixelsCorrection(uint16_t *pixels, float *to
                     ap[1] = to[pixels[pix]-1] - to[pixels[pix]-2];
                     if(fabs(ap[0]) > fabs(ap[1]))
                     {
-                        to[pixels[pix]] = to[pixels[pix]-1] + ap[1];                        
+                        to[pixels[pix]] = to[pixels[pix]-1] + ap[1];
                     }
                     else
                     {
-                        to[pixels[pix]] = to[pixels[pix]+1] + ap[0];                        
+                        to[pixels[pix]] = to[pixels[pix]+1] + ap[0];
                     }
                 }
                 else
                 {
-                    to[pixels[pix]] = (to[pixels[pix]-1]+to[pixels[pix]+1])/2.0;                    
-                }            
-            }                      
-        } 
-        pix = pix + 1;    
-    }    
+                    to[pixels[pix]] = (to[pixels[pix]-1]+to[pixels[pix]+1])/2.0;
+                }
+            }
+        }
+        pix = pix + 1;
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -700,9 +702,9 @@ void ExtractVDDParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 {
     int16_t kVdd;
     int16_t vdd25;
-    
+
     kVdd = eeData[51];
-    
+
     kVdd = (eeData[51] & 0xFF00) >> 8;
     if(kVdd > 127)
     {
@@ -711,9 +713,9 @@ void ExtractVDDParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     kVdd = 32 * kVdd;
     vdd25 = eeData[51] & 0x00FF;
     vdd25 = ((vdd25 - 256) << 5) - 8192;
-    
+
     mlx90640->kVdd = kVdd;
-    mlx90640->vdd25 = vdd25; 
+    mlx90640->vdd25 = vdd25;
 #ifdef MLX90640_DEBUG
     Serial.print("kVdd: "); Serial.println(kVdd);
     Serial.print("vdd25: "); Serial.println(vdd25);
@@ -728,7 +730,7 @@ void ExtractPTATParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     float KtPTAT;
     int16_t vPTAT25;
     float alphaPTAT;
-    
+
 
     KvPTAT = (eeData[50] & 0xFC00) >> 10;
     if(KvPTAT > 31)
@@ -736,20 +738,20 @@ void ExtractPTATParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         KvPTAT = KvPTAT - 64;
     }
     KvPTAT = KvPTAT/4096;
-    
+
     KtPTAT = eeData[50] & 0x03FF;
     if(KtPTAT > 511)
     {
         KtPTAT = KtPTAT - 1024;
     }
     KtPTAT = KtPTAT/8;
-    
+
     vPTAT25 = eeData[49];
-    
+
     alphaPTAT = (eeData[16] & 0xF000) / pow(2, (double)14) + 8.0f;
-    
+
     mlx90640->KvPTAT = KvPTAT;
-    mlx90640->KtPTAT = KtPTAT;    
+    mlx90640->KtPTAT = KtPTAT;
     mlx90640->vPTAT25 = vPTAT25;
     mlx90640->alphaPTAT = alphaPTAT;
 #ifdef MLX90640_DEBUG
@@ -765,13 +767,13 @@ void ExtractPTATParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 void ExtractGainParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 {
     int16_t gainEE;
-    
+
     gainEE = eeData[48];
     if(gainEE > 32767)
     {
         gainEE = gainEE -65536;
     }
-    
+
     mlx90640->gainEE = gainEE;
 #ifdef MLX90640_DEBUG
     Serial.print("gainEE: "); Serial.println(gainEE);
@@ -789,8 +791,8 @@ void ExtractTgcParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         tgc = tgc - 256;
     }
     tgc = tgc / 32.0f;
-    
-    mlx90640->tgc = tgc;        
+
+    mlx90640->tgc = tgc;
 #ifdef MLX90640_DEBUG
     Serial.print("tgc: "); Serial.println(tgc, 8);
 #endif
@@ -801,8 +803,8 @@ void ExtractTgcParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 void ExtractResolutionParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 {
     uint8_t resolutionEE;
-    resolutionEE = (eeData[56] & 0x3000) >> 12;    
-    
+    resolutionEE = (eeData[56] & 0x3000) >> 12;
+
     mlx90640->resolutionEE = resolutionEE;
 #ifdef MLX90640_DEBUG
     Serial.print("ResolutionEE: "); Serial.println(resolutionEE);
@@ -820,7 +822,7 @@ void ExtractKsTaParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         KsTa = KsTa -256;
     }
     KsTa = KsTa / 8192.0f;
-    
+
     mlx90640->KsTa = KsTa;
 #ifdef MLX90640_DEBUG
     Serial.print("KsTa: "); Serial.println(KsTa, 8);
@@ -833,26 +835,26 @@ void ExtractKsToParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 {
     int KsToScale;
     int8_t step;
-    
+
     step = ((eeData[63] & 0x3000) >> 12) * 10;
-    
+
     mlx90640->ct[0] = -40;
     mlx90640->ct[1] = 0;
     mlx90640->ct[2] = (eeData[63] & 0x00F0) >> 4;
-    mlx90640->ct[3] = (eeData[63] & 0x0F00) >> 8;    
-    
+    mlx90640->ct[3] = (eeData[63] & 0x0F00) >> 8;
+
     mlx90640->ct[2] = mlx90640->ct[2]*step;
     mlx90640->ct[3] = mlx90640->ct[2] + mlx90640->ct[3]*step;
     mlx90640->ct[4] = 400;
-    
+
     KsToScale = (eeData[63] & 0x000F) + 8;
     KsToScale = 1 << KsToScale;
-    
+
     mlx90640->ksTo[0] = eeData[61] & 0x00FF;
     mlx90640->ksTo[1] = (eeData[61] & 0xFF00) >> 8;
     mlx90640->ksTo[2] = eeData[62] & 0x00FF;
-    mlx90640->ksTo[3] = (eeData[62] & 0xFF00) >> 8;      
-    
+    mlx90640->ksTo[3] = (eeData[62] & 0xFF00) >> 8;
+
     for(int i = 0; i < 4; i++)
     {
         if(mlx90640->ksTo[i] > 127)
@@ -860,18 +862,18 @@ void ExtractKsToParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
             mlx90640->ksTo[i] = mlx90640->ksTo[i] - 256;
         }
         mlx90640->ksTo[i] = mlx90640->ksTo[i] / KsToScale;
-    } 
-    
+    }
+
     mlx90640->ksTo[4] = -0.0002;
 
 #ifdef MLX90640_DEBUG
-    Serial.print("KsTo: "); 
+    Serial.print("KsTo: ");
     for (int i=0; i<5; i++) {
       Serial.print(mlx90640->ksTo[i], 8);
       Serial.print(", ");
     }
     Serial.println();
-    Serial.print("ct: "); 
+    Serial.print("ct: ");
     for (int i=0; i<5; i++) {
       Serial.print(mlx90640->ct[i]);
       Serial.print(", ");
@@ -892,16 +894,15 @@ void ExtractAlphaParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     uint8_t accRowScale;
     uint8_t accColumnScale;
     uint8_t accRemScale;
-    float alphaTemp[768];
     float temp;
-    
+
 
     accRemScale = eeData[32] & 0x000F;
     accColumnScale = (eeData[32] & 0x00F0) >> 4;
     accRowScale = (eeData[32] & 0x0F00) >> 8;
     alphaScale = ((eeData[32] & 0xF000) >> 12) + 30;
     alphaRef = eeData[33];
-    
+
     for(int i = 0; i < 6; i++)
     {
         p = i * 4;
@@ -910,7 +911,7 @@ void ExtractAlphaParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         accRow[p + 2] = (eeData[34 + i] & 0x0F00) >> 8;
         accRow[p + 3] = (eeData[34 + i] & 0xF000) >> 12;
     }
-    
+
     for(int i = 0; i < 24; i++)
     {
         if (accRow[i] > 7)
@@ -918,7 +919,7 @@ void ExtractAlphaParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
             accRow[i] = accRow[i] - 16;
         }
     }
-    
+
     for(int i = 0; i < 8; i++)
     {
         p = i * 4;
@@ -927,7 +928,7 @@ void ExtractAlphaParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         accColumn[p + 2] = (eeData[40 + i] & 0x0F00) >> 8;
         accColumn[p + 3] = (eeData[40 + i] & 0xF000) >> 12;
     }
-    
+
     for(int i = 0; i < 32; i ++)
     {
         if (accColumn[i] > 7)
@@ -941,62 +942,62 @@ void ExtractAlphaParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         for(int j = 0; j < 32; j ++)
         {
             p = 32 * i +j;
-            alphaTemp[p] = (eeData[64 + p] & 0x03F0) >> 4;
-            if (alphaTemp[p] > 31)
+            scratchData[p] = (eeData[64 + p] & 0x03F0) >> 4;
+            if (scratchData[p] > 31)
             {
-                alphaTemp[p] = alphaTemp[p] - 64;
+                scratchData[p] = scratchData[p] - 64;
             }
-            alphaTemp[p] = alphaTemp[p]*(1 << accRemScale);
-            alphaTemp[p] = (alphaRef + (accRow[i] << accRowScale) + (accColumn[j] << accColumnScale) + alphaTemp[p]);
-            alphaTemp[p] = alphaTemp[p] / pow(2,(double)alphaScale);
-            alphaTemp[p] = alphaTemp[p] - mlx90640->tgc * (mlx90640->cpAlpha[0] + mlx90640->cpAlpha[1])/2;
-            alphaTemp[p] = SCALEALPHA/alphaTemp[p];
+            scratchData[p] = scratchData[p]*(1 << accRemScale);
+            scratchData[p] = (alphaRef + (accRow[i] << accRowScale) + (accColumn[j] << accColumnScale) + scratchData[p]);
+            scratchData[p] = scratchData[p] / pow(2,(double)alphaScale);
+            scratchData[p] = scratchData[p] - mlx90640->tgc * (mlx90640->cpAlpha[0] + mlx90640->cpAlpha[1])/2;
+            scratchData[p] = SCALEALPHA/scratchData[p];
         }
     }
 #ifdef MLX90640_DEBUG
-    Serial.print("alphaTemp: "); 
+    Serial.print("scratchData: ");
     for (int i=0; i<768; i++) {
-      Serial.print(alphaTemp[i], 8);
+      Serial.print(scratchData[i], 8);
       Serial.print(", ");
     }
     Serial.println();
 #endif
 
-    temp = alphaTemp[0];
+    temp = scratchData[0];
     for(int i = 1; i < 768; i++)
     {
-        if (alphaTemp[i] > temp)
+        if (scratchData[i] > temp)
         {
-            temp = alphaTemp[i];
+            temp = scratchData[i];
         }
     }
 #ifdef MLX90640_DEBUG
     Serial.print("Temp: "); Serial.println(temp);
 #endif
-    
+
     alphaScale = 0;
     while(temp < 32768)
     {
         temp = temp*2;
         alphaScale = alphaScale + 1;
-    } 
-    
+    }
+
     for(int i = 0; i < 768; i++)
     {
-        temp = alphaTemp[i] * pow(2,(double)alphaScale);        
-        mlx90640->alpha[i] = (temp + 0.5);        
-        
-    } 
+        temp = scratchData[i] * pow(2,(double)alphaScale);
+        mlx90640->alpha[i] = (temp + 0.5);
 
-    mlx90640->alphaScale = alphaScale;      
-   
+    }
+
+    mlx90640->alphaScale = alphaScale;
+
 #ifdef MLX90640_DEBUG
-    Serial.print("alpha: "); 
+    Serial.print("alpha: ");
     for (int i=0; i<768; i++) {
       Serial.print(mlx90640->alpha[i]);
       Serial.print(", ");
     }
-    Serial.println(); 
+    Serial.println();
     Serial.print("alphascale: "); Serial.println(alphaScale);
 #endif
 }
@@ -1012,7 +1013,7 @@ void ExtractOffsetParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     uint8_t occRowScale;
     uint8_t occColumnScale;
     uint8_t occRemScale;
-    
+
 
     occRemScale = (eeData[16] & 0x000F);
     occColumnScale = (eeData[16] & 0x00F0) >> 4;
@@ -1022,7 +1023,7 @@ void ExtractOffsetParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     {
         offsetRef = offsetRef - 65536;
     }
-    
+
     for(int i = 0; i < 6; i++)
     {
         p = i * 4;
@@ -1031,7 +1032,7 @@ void ExtractOffsetParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         occRow[p + 2] = (eeData[18 + i] & 0x0F00) >> 8;
         occRow[p + 3] = (eeData[18 + i] & 0xF000) >> 12;
     }
-    
+
     for(int i = 0; i < 24; i++)
     {
         if (occRow[i] > 7)
@@ -1039,7 +1040,7 @@ void ExtractOffsetParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
             occRow[i] = occRow[i] - 16;
         }
     }
-    
+
     for(int i = 0; i < 8; i++)
     {
         p = i * 4;
@@ -1048,7 +1049,7 @@ void ExtractOffsetParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         occColumn[p + 2] = (eeData[24 + i] & 0x0F00) >> 8;
         occColumn[p + 3] = (eeData[24 + i] & 0xF000) >> 12;
     }
-    
+
     for(int i = 0; i < 32; i ++)
     {
         if (occColumn[i] > 7)
@@ -1072,12 +1073,12 @@ void ExtractOffsetParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         }
     }
 #ifdef MLX90640_DEBUG
-    Serial.print("offset: "); 
+    Serial.print("offset: ");
     for (int i=0; i<768; i++) {
       Serial.print(mlx90640->offset[i]);
       Serial.print(", ");
     }
-    Serial.println(); 
+    Serial.println();
 #endif
 }
 
@@ -1094,37 +1095,36 @@ void ExtractKtaPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     uint8_t ktaScale1;
     uint8_t ktaScale2;
     uint8_t split;
-    float ktaTemp[768];
     float temp;
-    
+
     KtaRoCo = (eeData[54] & 0xFF00) >> 8;
     if (KtaRoCo > 127)
     {
         KtaRoCo = KtaRoCo - 256;
     }
     KtaRC[0] = KtaRoCo;
-    
+
     KtaReCo = (eeData[54] & 0x00FF);
     if (KtaReCo > 127)
     {
         KtaReCo = KtaReCo - 256;
     }
     KtaRC[2] = KtaReCo;
-      
+
     KtaRoCe = (eeData[55] & 0xFF00) >> 8;
     if (KtaRoCe > 127)
     {
         KtaRoCe = KtaRoCe - 256;
     }
     KtaRC[1] = KtaRoCe;
-      
+
     KtaReCe = (eeData[55] & 0x00FF);
     if (KtaReCe > 127)
     {
         KtaReCe = KtaReCe - 256;
     }
     KtaRC[3] = KtaReCe;
-  
+
     ktaScale1 = ((eeData[56] & 0x00F0) >> 4) + 8;
     ktaScale2 = (eeData[56] & 0x000F);
 
@@ -1134,37 +1134,37 @@ void ExtractKtaPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         {
             p = 32 * i +j;
             split = 2*(p/32 - (p/64)*2) + p%2;
-            ktaTemp[p] = (eeData[64 + p] & 0x000E) >> 1;
-            if (ktaTemp[p] > 3)
+            scratchData[p] = (eeData[64 + p] & 0x000E) >> 1;
+            if (scratchData[p] > 3)
             {
-                ktaTemp[p] = ktaTemp[p] - 8;
+                scratchData[p] = scratchData[p] - 8;
             }
-            ktaTemp[p] = ktaTemp[p] * (1 << ktaScale2);
-            ktaTemp[p] = KtaRC[split] + ktaTemp[p];
-            ktaTemp[p] = ktaTemp[p] / pow(2,(double)ktaScale1);
-            //ktaTemp[p] = ktaTemp[p] * mlx90640->offset[p];
+            scratchData[p] = scratchData[p] * (1 << ktaScale2);
+            scratchData[p] = KtaRC[split] + scratchData[p];
+            scratchData[p] = scratchData[p] / pow(2,(double)ktaScale1);
+            //scratchData[p] = scratchData[p] * mlx90640->offset[p];
         }
     }
-    
-    temp = fabs(ktaTemp[0]);
+
+    temp = fabs(scratchData[0]);
     for(int i = 1; i < 768; i++)
     {
-        if (fabs(ktaTemp[i]) > temp)
+        if (fabs(scratchData[i]) > temp)
         {
-            temp = fabs(ktaTemp[i]);
+            temp = fabs(scratchData[i]);
         }
     }
-    
+
     ktaScale1 = 0;
     while(temp < 64)
     {
         temp = temp*2;
         ktaScale1 = ktaScale1 + 1;
-    }    
-     
+    }
+
     for(int i = 0; i < 768; i++)
     {
-        temp = ktaTemp[i] * pow(2,(double)ktaScale1);
+        temp = scratchData[i] * pow(2,(double)ktaScale1);
         if (temp < 0)
         {
             mlx90640->kta[i] = (temp - 0.5);
@@ -1172,19 +1172,19 @@ void ExtractKtaPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         else
         {
             mlx90640->kta[i] = (temp + 0.5);
-        }        
-        
-    } 
-    
-    mlx90640->ktaScale = ktaScale1;           
+        }
+
+    }
+
+    mlx90640->ktaScale = ktaScale1;
 
 #ifdef MLX90640_DEBUG
-    Serial.print("kta: "); 
+    Serial.print("kta: ");
     for (int i=0; i<768; i++) {
       Serial.print(mlx90640->kta[i]);
       Serial.print(", ");
     }
-    Serial.println(); 
+    Serial.println();
     Serial.print("ktascale: "); Serial.println(ktaScale1);
 #endif
 }
@@ -1202,7 +1202,6 @@ void ExtractKvPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     int8_t KvReCe;
     uint8_t kvScale;
     uint8_t split;
-    float kvTemp[768];
     float temp;
 
     KvRoCo = (eeData[52] & 0xF000) >> 12;
@@ -1211,28 +1210,28 @@ void ExtractKvPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         KvRoCo = KvRoCo - 16;
     }
     KvT[0] = KvRoCo;
-    
+
     KvReCo = (eeData[52] & 0x0F00) >> 8;
     if (KvReCo > 7)
     {
         KvReCo = KvReCo - 16;
     }
     KvT[2] = KvReCo;
-      
+
     KvRoCe = (eeData[52] & 0x00F0) >> 4;
     if (KvRoCe > 7)
     {
         KvRoCe = KvRoCe - 16;
     }
     KvT[1] = KvRoCe;
-      
+
     KvReCe = (eeData[52] & 0x000F);
     if (KvReCe > 7)
     {
         KvReCe = KvReCe - 16;
     }
     KvT[3] = KvReCe;
-  
+
     kvScale = (eeData[56] & 0x0F00) >> 8;
 
 
@@ -1242,31 +1241,31 @@ void ExtractKvPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         {
             p = 32 * i +j;
             split = 2*(p/32 - (p/64)*2) + p%2;
-            kvTemp[p] = KvT[split];
-            kvTemp[p] = kvTemp[p] / pow(2,(double)kvScale);
-            //kvTemp[p] = kvTemp[p] * mlx90640->offset[p];
+            scratchData[p] = KvT[split];
+            scratchData[p] = scratchData[p] / pow(2,(double)kvScale);
+            //scratchData[p] = scratchData[p] * mlx90640->offset[p];
         }
     }
-    
-    temp = fabs(kvTemp[0]);
+
+    temp = fabs(scratchData[0]);
     for(int i = 1; i < 768; i++)
     {
-        if (fabs(kvTemp[i]) > temp)
+        if (fabs(scratchData[i]) > temp)
         {
-            temp = fabs(kvTemp[i]);
+            temp = fabs(scratchData[i]);
         }
     }
-    
+
     kvScale = 0;
     while(temp < 64)
     {
         temp = temp*2;
         kvScale = kvScale + 1;
-    }    
-     
+    }
+
     for(int i = 0; i < 768; i++)
     {
-        temp = kvTemp[i] * pow(2,(double)kvScale);
+        temp = scratchData[i] * pow(2,(double)kvScale);
         if (temp < 0)
         {
             mlx90640->kv[i] = (temp - 0.5);
@@ -1274,19 +1273,19 @@ void ExtractKvPixelParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         else
         {
             mlx90640->kv[i] = (temp + 0.5);
-        }        
-        
-    } 
-    
-    mlx90640->kvScale = kvScale;        
+        }
+
+    }
+
+    mlx90640->kvScale = kvScale;
 
 #ifdef MLX90640_DEBUG
-    Serial.print("kv: "); 
+    Serial.print("kv: ");
     for (int i=0; i<768; i++) {
       Serial.print(mlx90640->kv[i]);
       Serial.print(", ");
     }
-    Serial.println(); 
+    Serial.println();
     Serial.print("kvscale: "); Serial.println(kvScale);
 #endif
 }
@@ -1304,42 +1303,42 @@ void ExtractCPParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     uint8_t kvScale;
 
     alphaScale = ((eeData[32] & 0xF000) >> 12) + 27;
-    
+
     offsetSP[0] = (eeData[58] & 0x03FF);
     if (offsetSP[0] > 511)
     {
         offsetSP[0] = offsetSP[0] - 1024;
     }
-    
+
     offsetSP[1] = (eeData[58] & 0xFC00) >> 10;
     if (offsetSP[1] > 31)
     {
         offsetSP[1] = offsetSP[1] - 64;
     }
-    offsetSP[1] = offsetSP[1] + offsetSP[0]; 
-    
+    offsetSP[1] = offsetSP[1] + offsetSP[0];
+
     alphaSP[0] = (eeData[57] & 0x03FF);
     if (alphaSP[0] > 511)
     {
         alphaSP[0] = alphaSP[0] - 1024;
     }
     alphaSP[0] = alphaSP[0] /  pow(2,(double)alphaScale);
-    
+
     alphaSP[1] = (eeData[57] & 0xFC00) >> 10;
     if (alphaSP[1] > 31)
     {
         alphaSP[1] = alphaSP[1] - 64;
     }
     alphaSP[1] = (1 + alphaSP[1]/128) * alphaSP[0];
-    
+
     cpKta = (eeData[59] & 0x00FF);
     if (cpKta > 127)
     {
         cpKta = cpKta - 256;
     }
-    ktaScale1 = ((eeData[56] & 0x00F0) >> 4) + 8;    
+    ktaScale1 = ((eeData[56] & 0x00F0) >> 4) + 8;
     mlx90640->cpKta = cpKta / pow(2,(double)ktaScale1);
-    
+
     cpKv = (eeData[59] & 0xFF00) >> 8;
     if (cpKv > 127)
     {
@@ -1347,11 +1346,11 @@ void ExtractCPParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
     }
     kvScale = (eeData[56] & 0x0F00) >> 8;
     mlx90640->cpKv = cpKv / pow(2,(double)kvScale);
-       
+
     mlx90640->cpAlpha[0] = alphaSP[0];
     mlx90640->cpAlpha[1] = alphaSP[1];
     mlx90640->cpOffset[0] = offsetSP[0];
-    mlx90640->cpOffset[1] = offsetSP[1];  
+    mlx90640->cpOffset[1] = offsetSP[1];
 
 #ifdef MLX90640_DEBUG
     Serial.print("cpAlpha: "); Serial.print(alphaSP[0], 12);
@@ -1367,7 +1366,7 @@ void ExtractCILCParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
 {
     float ilChessC[3];
     uint8_t calibrationModeEE;
-    
+
     calibrationModeEE = (eeData[10] & 0x0800) >> 4;
     calibrationModeEE = calibrationModeEE ^ 0x80;
 
@@ -1377,21 +1376,21 @@ void ExtractCILCParameters(uint16_t *eeData, paramsMLX90640 *mlx90640)
         ilChessC[0] = ilChessC[0] - 64;
     }
     ilChessC[0] = ilChessC[0] / 16.0f;
-    
+
     ilChessC[1] = (eeData[53] & 0x07C0) >> 6;
     if (ilChessC[1] > 15)
     {
         ilChessC[1] = ilChessC[1] - 32;
     }
     ilChessC[1] = ilChessC[1] / 2.0f;
-    
+
     ilChessC[2] = (eeData[53] & 0xF800) >> 11;
     if (ilChessC[2] > 15)
     {
         ilChessC[2] = ilChessC[2] - 32;
     }
     ilChessC[2] = ilChessC[2] / 8.0f;
-    
+
     mlx90640->calibrationModeEE = calibrationModeEE;
     mlx90640->ilChessC[0] = ilChessC[0];
     mlx90640->ilChessC[1] = ilChessC[1];
@@ -1414,49 +1413,49 @@ int ExtractDeviatingPixels(uint16_t *eeData, paramsMLX90640 *mlx90640)
     uint16_t outlierPixCnt = 0;
     int warn = 0;
     int i;
-    
+
     for(pixCnt = 0; pixCnt<5; pixCnt++)
     {
         mlx90640->brokenPixels[pixCnt] = 0xFFFF;
         mlx90640->outlierPixels[pixCnt] = 0xFFFF;
     }
-        
-    pixCnt = 0;    
+
+    pixCnt = 0;
     while (pixCnt < 768 && brokenPixCnt < 5 && outlierPixCnt < 5)
     {
         if(eeData[pixCnt+64] == 0)
         {
             mlx90640->brokenPixels[brokenPixCnt] = pixCnt;
             brokenPixCnt = brokenPixCnt + 1;
-        }    
+        }
         else if((eeData[pixCnt+64] & 0x0001) != 0)
         {
             mlx90640->outlierPixels[outlierPixCnt] = pixCnt;
             outlierPixCnt = outlierPixCnt + 1;
-        }    
-        
+        }
+
         pixCnt = pixCnt + 1;
-        
-    } 
-    
-    if(brokenPixCnt > 4)  
+
+    }
+
+    if(brokenPixCnt > 4)
     {
       Serial.print("Broken pixels: ");
       Serial.println(brokenPixCnt);
         warn = -3;
-    }         
-    else if(outlierPixCnt > 4)  
+    }
+    else if(outlierPixCnt > 4)
     {
       Serial.print("Outlier pixels: ");
       Serial.println(outlierPixCnt);
         warn = -4;
     }
-    else if((brokenPixCnt + outlierPixCnt) > 4)  
+    else if((brokenPixCnt + outlierPixCnt) > 4)
     {
       Serial.print("Broken+outlier pixels: ");
       Serial.println(brokenPixCnt + outlierPixCnt);
         warn = -5;
-    } 
+    }
     else
     {
         for(pixCnt=0; pixCnt<brokenPixCnt; pixCnt++)
@@ -1468,10 +1467,10 @@ int ExtractDeviatingPixels(uint16_t *eeData, paramsMLX90640 *mlx90640)
                 {
 		    Serial.println("Broken pixel has adjacent broken pixel");
                     return warn;
-                }    
-            }    
+                }
+            }
         }
-        
+
         for(pixCnt=0; pixCnt<outlierPixCnt; pixCnt++)
         {
             for(i=pixCnt+1; i<outlierPixCnt; i++)
@@ -1481,10 +1480,10 @@ int ExtractDeviatingPixels(uint16_t *eeData, paramsMLX90640 *mlx90640)
                 {
 		    Serial.println("Outlier pixel has adjacent outlier pixel");
                     return warn;
-                }    
-            }    
-        } 
-        
+                }
+            }
+        }
+
         for(pixCnt=0; pixCnt<brokenPixCnt; pixCnt++)
         {
             for(i=0; i<outlierPixCnt; i++)
@@ -1494,15 +1493,15 @@ int ExtractDeviatingPixels(uint16_t *eeData, paramsMLX90640 *mlx90640)
                 {
 		    Serial.println("Broken pixel has adjacent outlier pixel");
                     return warn;
-                }    
-            }    
-        }    
-        
-    }    
-    
-    
+                }
+            }
+        }
+
+    }
+
+
     return warn;
-       
+
 }
 
 //------------------------------------------------------------------------------
@@ -1510,54 +1509,54 @@ int ExtractDeviatingPixels(uint16_t *eeData, paramsMLX90640 *mlx90640)
  int CheckAdjacentPixels(uint16_t pix1, uint16_t pix2)
  {
      int pixPosDif;
-     
+
      pixPosDif = pix1 - pix2;
      if(pixPosDif > -34 && pixPosDif < -30)
      {
          return -6;
-     } 
+     }
      if(pixPosDif > -2 && pixPosDif < 2)
      {
          return -6;
-     } 
+     }
      if(pixPosDif > 30 && pixPosDif < 34)
      {
          return -6;
      }
-     
-     return 0;    
+
+     return 0;
  }
- 
+
 //------------------------------------------------------------------------------
- 
+
 float GetMedian(float *values, int n)
  {
     float temp;
-    
+
     for(int i=0; i<n-1; i++)
     {
         for(int j=i+1; j<n; j++)
         {
-            if(values[j] < values[i]) 
-            {                
+            if(values[j] < values[i])
+            {
                 temp = values[i];
                 values[i] = values[j];
                 values[j] = temp;
             }
         }
     }
-    
-    if(n%2==0) 
+
+    if(n%2==0)
     {
         return ((values[n/2] + values[n/2 - 1]) / 2.0);
-        
-    } 
-    else 
+
+    }
+    else
     {
         return values[n/2];
     }
-    
- }           
+
+ }
 
 //------------------------------------------------------------------------------
 
@@ -1568,10 +1567,10 @@ int IsPixelBad(uint16_t pixel,paramsMLX90640 *params)
         if(pixel == params->outlierPixels[i] || pixel == params->brokenPixels[i])
         {
             return 1;
-        }    
-    }   
-    
-    return 0;     
-}     
+        }
+    }
+
+    return 0;
+}
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2.

Thanks to @JVaassen for the tip (see issue thread).

Several methods in `MLX90640_API.cpp` were creating a 768 element float array that was causing memory allocation grief. Moved this to a single global `scratchData` array that they all use.

Tested with example from issue thread as well as the `MLX90640_simpletest.ino` example from this library on a Feather ESP8266 and Feather M0 basic proto.

Here is ASCII art image on me giving a thumbs up:
```
-------.---.-...-..--.-.--------
.------.--...-.-.-.-----------.-
-.---.-.-...-.-.-.---.----------
------.-...........-------------
-...-.......-.......--*-*-------
.-...-.......-.--..---***-------
....-...-.-.---.-.-.--****------
.....-....---*---..---****------
-...-...--++x+++--..-.--***-----
.-...-.--*++xxxx*-.-.---****----
.......-*+x+++%%x*..-..-**+*----
.......-+x%%**xxx+.-...--***----
....-.--x%%%x+++**-...-.-*++*---
----..-*%%%xxx++++-....---++**--
-.-.-.-*%%%x%xxxx+-.-...--+++*--
-------+%%%%%%%%x+--.....-++++--
-.---.-*%%%%%%#%+--...-.--++x+**
--------%%%%%%%%*-....-..-+++x**
*--.-.--%%%%xx++-.---...--++xx+*
++**---*%%%%xx+*.-.....---++xx++
xxx+x+xx%%%%%x*--.-.-.----*+xxx+
xxxxxxxxxxx%%%--..-..-----++xx++
xxx+xxxxxxxxx+---.-.------*+xxx+
xxxxxxxxxxxxxx*-----------++xxx+
```