### PR TITLE
Add support for getting ambient temperature

### DIFF
--- a/Adafruit_MLX90640.cpp
+++ b/Adafruit_MLX90640.cpp
@@ -185,9 +185,9 @@ int Adafruit_MLX90640::getFrame(float *framebuf) {
       return status;
     }
 
-    tr = MLX90640_GetTa(mlx90640Frame, &_params) -
-         OPENAIR_TA_SHIFT; // For a MLX90640 in the open air the shift is -8
-                           // degC.
+    ta = MLX90640_GetTa(mlx90640Frame, &_params); // Store ambient temp locally
+    tr = ta - OPENAIR_TA_SHIFT; // For a MLX90640 in the open air the shift is
+                                // -8 degC.
 #ifdef MLX90640_DEBUG
     Serial.print("Tr = ");
     Serial.println(tr, 8);
@@ -195,4 +195,19 @@ int Adafruit_MLX90640::getFrame(float *framebuf) {
     MLX90640_CalculateTo(mlx90640Frame, &_params, emissivity, tr, framebuf);
   }
   return 0;
+}
+
+/*!
+ *    @brief  Return ambient temperature.
+ *    @param  newFrame If true, will also capture a new data frame. If false,
+ * return the value from the last data frame read.
+ *    @return Ambient temperature as a float in degrees Celsius.
+ */
+float Adafruit_MLX90640::getTa(bool newFrame) {
+  if (!newFrame) {
+    return ta;
+  }
+  uint16_t mlx90640Frame[834];
+  MLX90640_GetFrameData(0, mlx90640Frame);
+  return MLX90640_GetTa(mlx90640Frame, &_params);
 }

--- a/Adafruit_MLX90640.cpp
+++ b/Adafruit_MLX90640.cpp
@@ -198,7 +198,7 @@ int Adafruit_MLX90640::getFrame(float *framebuf) {
 }
 
 /*!
- *    @brief  Return ambient temperature.
+ *    @brief  Return ambient temperature of the TO39 package.
  *    @param  newFrame If true, will also capture a new data frame. If false,
  * return the value from the last data frame read.
  *    @return Ambient temperature as a float in degrees Celsius.

--- a/Adafruit_MLX90640.h
+++ b/Adafruit_MLX90640.h
@@ -73,6 +73,8 @@ public:
 
   int getFrame(float *framebuf);
 
+  float getTa(bool newFrame=true);
+
   uint16_t serialNumber[3]; ///< Unique serial number read from device
 
 private:
@@ -83,6 +85,7 @@ private:
 
   Adafruit_I2CDevice *i2c_dev;
   paramsMLX90640 _params;
+  float ta = -999.0;
 
   int MLX90640_DumpEE(uint8_t slaveAddr, uint16_t *eeData);
   int MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameData);

--- a/Adafruit_MLX90640.h
+++ b/Adafruit_MLX90640.h
@@ -73,7 +73,7 @@ public:
 
   int getFrame(float *framebuf);
 
-  float getTa(bool newFrame=true);
+  float getTa(bool newFrame = true);
 
   uint16_t serialNumber[3]; ///< Unique serial number read from device
 

--- a/examples/MLX90640_simpletest/MLX90640_simpletest.ino
+++ b/examples/MLX90640_simpletest/MLX90640_simpletest.ino
@@ -23,14 +23,14 @@ void setup() {
   Serial.print(mlx.serialNumber[0], HEX);
   Serial.print(mlx.serialNumber[1], HEX);
   Serial.println(mlx.serialNumber[2], HEX);
-  
+
   //mlx.setMode(MLX90640_INTERLEAVED);
   mlx.setMode(MLX90640_CHESS);
   Serial.print("Current mode: ");
   if (mlx.getMode() == MLX90640_CHESS) {
     Serial.println("Chess");
   } else {
-    Serial.println("Interleave");    
+    Serial.println("Interleave");
   }
 
   mlx.setResolution(MLX90640_ADC_18BIT);
@@ -48,7 +48,7 @@ void setup() {
   mlx90640_refreshrate_t rate = mlx.getRefreshRate();
   switch (rate) {
     case MLX90640_0_5_HZ: Serial.println("0.5 Hz"); break;
-    case MLX90640_1_HZ: Serial.println("1 Hz"); break; 
+    case MLX90640_1_HZ: Serial.println("1 Hz"); break;
     case MLX90640_2_HZ: Serial.println("2 Hz"); break;
     case MLX90640_4_HZ: Serial.println("4 Hz"); break;
     case MLX90640_8_HZ: Serial.println("8 Hz"); break;
@@ -64,6 +64,10 @@ void loop() {
     Serial.println("Failed");
     return;
   }
+  Serial.println("===================================");
+  Serial.print("Ambient temperature = ");
+  Serial.print(mlx.getTa(false)); // false = no new frame capture
+  Serial.println(" degC");
   Serial.println();
   Serial.println();
   for (uint8_t h=0; h<24; h++) {


### PR DESCRIPTION
For #4 

Adds new `getTa()` public method, along with new `ta` local, to provide user access to the ambient temperature* value from the MLX90640 data frame.

* ambient temperature is "the temperature of the TO39 package" per the datasheet


Example updated and tested on QT PY M0.

```
Ambient temperature = 25.89 degC


--------------------------------
--------------------------------
-----------------.--------------
--------------------------------
--------------------------------
------*-****--------------------
------***+*+--------------------
-----***+*x**-------------------
----*++++++x**-------*-*--------
----++x+++x++-------*-*---------
---*+xx%xxxx+*-----*-+*+*-------
---*x+%x%%%%x+------**+***------
---*+xx#%#%%++---.--***+**------
---*xx#%#x%%x+------**+++*------
---*xx%%%%%%x**-------+++**-----
---*+xx%%%%%*+-------**+++**----
--**++%+%xx++-*-------**++**----
****+x+%+%+x-+---------*++++*---
***++xx+x+x*+-*---------*+++**--
+*+*x++x+x+x-*----------*++++*--
*++x++++x+x+*-----------**+x++**
x*x++++++x+++**----------*++++**
+x+xx++x++x+*+*+-+-+-*-*-*+xxx+*
%+xx+x+++++x+*+*+*x*+-+-+*x+xx++
```